### PR TITLE
Add pre-commit ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@ repos:
     rev: 'v0.0.256'
     hooks:
       - id: ruff
+        args: [--fix, --exit-non-zero-on-fix]
 
   - repo: https://github.com/psf/black
     rev: '23.1.0'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,15 @@ repos:
     rev: '23.1.0'
     hooks:
       - id: black
+
+ci:
+    # autofix_commit_msg: |
+    #     [pre-commit.ci] auto fixes from pre-commit.com hooks
+
+    #     for more information, see https://pre-commit.ci
+    autofix_prs: false
+    # autoupdate_branch: ''
+    # autoupdate_commit_msg: '[pre-commit.ci] pre-commit autoupdate'
+    # autoupdate_schedule: weekly
+    # skip: []
+    # submodules: false

--- a/file_needing_precommit_fixes.py
+++ b/file_needing_precommit_fixes.py
@@ -1,2 +1,1 @@
 """My module"""
-import os

--- a/file_needing_precommit_fixes.py
+++ b/file_needing_precommit_fixes.py
@@ -1,0 +1,2 @@
+"""My module"""
+import os


### PR DESCRIPTION
Adds linting CI from https://pre-commit.ci/

Configured with autofixing turned off, devs may invoke this by commenting `"pre-commit.ci autofix"`