### PR TITLE
Drop support for asdf<3 and numpy<1.25

### DIFF
--- a/.github/workflows/test.v2.yaml
+++ b/.github/workflows/test.v2.yaml
@@ -26,6 +26,5 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install hatch
-        hatch env create
     - name: Pytest
-      run: hatch run test
+      run: hatch run +py=${{ matrix.python-version }} test:test

--- a/.github/workflows/test.v2.yaml
+++ b/.github/workflows/test.v2.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
     strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
 dependencies = [
   "asdf>=3",
   "pydantic>=2",
-  "numpy>=1.25"
+  "numpy>=1.25",
+  "numpy<2;python_version<'3.10'",
 ]
 dynamic = ["version"]
 
@@ -63,13 +64,20 @@ matrix-name-format = "{variable}={value}"
 test = "pytest {args}"
 
 [[tool.hatch.envs.test.matrix]]
-python = ["3.9", "3.10", "3.11", "3.12"]
+# Only test with numpy v1 on Python 3.9
+python = ["3.9"]
+numpy-version = ["1"]
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.10", "3.11", "3.12"]
 numpy-version = ["1", "2"]
+
 
 [tool.hatch.envs.test.overrides]
 matrix.numpy-version.dependencies = [
   { value = "numpy>=1,<2", if = ["1"] },
   { value = "numpy>=2,<3", if = ["2"] },
+  { value = "astropy>=6.1", if = ["2"] },
 ]
 
 [tool.hatch.envs.docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ matrix-name-format = "{variable}={value}"
 test = "pytest {args}"
 
 [[tool.hatch.envs.test.matrix]]
+python = ["3.9", "3.10", "3.11", "3.12"]
 numpy-version = ["1", "2"]
 
 [tool.hatch.envs.test.overrides]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
   "asdf>=3",
   "pydantic>=2",
+  "numpy>=1.25"
 ]
 dynamic = ["version"]
 
@@ -53,6 +54,22 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 test = "pytest {args}"
 test-cov = "test --cov-report=term-missing --cov-config=pyproject.toml --cov=asdf_pydantic --cov=tests {args}"
+
+[tool.hatch.envs.test]
+template = "default"
+matrix-name-format = "{variable}={value}"
+
+[tool.hatch.envs.test.scripts]
+test = "pytest {args}"
+
+[[tool.hatch.envs.test.matrix]]
+numpy-version = ["1", "2"]
+
+[tool.hatch.envs.test.overrides]
+matrix.numpy-version.dependencies = [
+  { value = "numpy>=1,<2", if = ["1"] },
+  { value = "numpy>=2,<3", if = ["2"] },
+]
 
 [tool.hatch.envs.docs]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "asdf>=2",
+  "asdf>=3",
   "pydantic>=2",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
- Added test matrix for both numpy v1 and v2
- Drop support for Python 3.9 with numpy v2 due to astropy constraints
