### PR TITLE
fix: pydantic cannot validate asdf `TaggedDict`, casting to native dict

### DIFF
--- a/asdf_pydantic/converter.py
+++ b/asdf_pydantic/converter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Type
 
 from asdf.extension import Converter
+from asdf.tagged import TaggedDict
 
 from asdf_pydantic.model import AsdfPydanticModel
 
@@ -40,4 +41,11 @@ class AsdfPydanticConverter(Converter):
         return obj.asdf_yaml_tree()
 
     def from_yaml_tree(self, node, tag, ctx):
-        return self._tag_to_class[tag].parse_obj(node)
+        def node_to_dict(node_: TaggedDict | dict):
+            """Converter node with possible nested TaggedDict to simple dict."""
+            # Recursive DFS
+            if not isinstance(node_, (dict, TaggedDict)):
+                return node_
+            return {k: node_to_dict(v) for k, v in node_.items()}
+
+        return self._tag_to_class[tag].model_validate(node_to_dict(node))

--- a/asdf_pydantic/converter.py
+++ b/asdf_pydantic/converter.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Type
 
 from asdf.extension import Converter
-from asdf.tagged import TaggedDict
 
 from asdf_pydantic.model import AsdfPydanticModel
 
@@ -41,11 +40,4 @@ class AsdfPydanticConverter(Converter):
         return obj.asdf_yaml_tree()
 
     def from_yaml_tree(self, node, tag, ctx):
-        def node_to_dict(node_: TaggedDict | dict):
-            """Converter node with possible nested TaggedDict to simple dict."""
-            # Recursive DFS
-            if not isinstance(node_, (dict, TaggedDict)):
-                return node_
-            return {k: node_to_dict(v) for k, v in node_.items()}
-
-        return self._tag_to_class[tag].model_validate(node_to_dict(node))
+        return self._tag_to_class[tag].parse_obj(node)

--- a/asdf_pydantic/model.py
+++ b/asdf_pydantic/model.py
@@ -1,8 +1,9 @@
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import yaml
 from asdf.extension import TagDefinition
-from pydantic import BaseModel, ConfigDict
+from asdf.tagged import TaggedDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from typing_extensions import deprecated
 
 from asdf_pydantic.schema import DEFAULT_ASDF_SCHEMA_REF_TEMPLATE, GenerateAsdfSchema
@@ -41,6 +42,11 @@ class AsdfPydanticModel(BaseModel):
                 )
 
         return d
+
+    @model_validator(mode="before")
+    @classmethod
+    def handle_asdf_tagged_dict_compat(cls, data: Any) -> dict:
+        return dict(data) if isinstance(data, TaggedDict) else data
 
     @classmethod
     def get_tag_definition(cls):

--- a/tests/examples/test_nested.py
+++ b/tests/examples/test_nested.py
@@ -1,0 +1,59 @@
+import asdf
+import pytest
+import yaml
+from asdf.extension import Extension
+
+from asdf_pydantic import AsdfPydanticConverter, AsdfPydanticModel
+
+
+class MetaModel(AsdfPydanticModel):
+    _tag = "asdf://asdf-pydantic/examples/tags/meta-model-1.0.0"
+    author: str
+
+
+class DataModel(AsdfPydanticModel):
+    _tag = "asdf://asdf-pydantic/examples/tags/data-model-1.0.0"
+    value: int
+
+
+class MainModel(AsdfPydanticModel):
+    _tag = "asdf://asdf-pydantic/examples/tags/main-model-1.0.0"
+    meta: MetaModel
+    data: DataModel
+
+
+@pytest.fixture()
+def asdf_extension():
+    """Registers an ASDF extension containing models for this test."""
+
+    converter = AsdfPydanticConverter()
+    converter.add_models(MainModel, DataModel, MetaModel)
+
+    class TestExtension(Extension):
+        extension_uri = "asdf://asdf-pydantic/examples/extensions/test-1.0.0"
+
+        converters = [converter]  # type: ignore
+        tags = [MainModel.get_tag_definition()]  # type: ignore
+
+    with asdf.config_context() as asdf_config:
+        asdf_config.add_resource_mapping(
+            {
+                yaml.safe_load(MainModel.model_asdf_schema())[
+                    "id"
+                ]: MainModel.model_asdf_schema()
+            }
+        )
+        asdf_config.add_extension(TestExtension())
+        yield asdf_config
+
+
+@pytest.mark.usefixtures("asdf_extension")
+def test_can_write_valid_asdf_file(tmp_path):
+    """Tests using the model to write an ASDF file validates its own schema."""
+    af = asdf.AsdfFile()
+    af["root"] = MainModel(data=DataModel(value=1), meta=MetaModel(author="foobar"))
+    af.validate()
+    af.write_to(tmp_path / "test.asdf")
+
+    with asdf.open(tmp_path / "test.asdf") as af:
+        assert af.tree


### PR DESCRIPTION
ASDF passes TaggedDict as YAML tree node to converter. Due to its multiple-inheritance implementation (UserDict, dict), Pydantic does not properly validate it and gives missing field errors.