### PR TITLE
refactor: remove deprecated `BaseModel `method `__fields__`, `parse_obj` and `_get_value`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# uv
+uv.lock

--- a/asdf_pydantic/converter.py
+++ b/asdf_pydantic/converter.py
@@ -40,4 +40,4 @@ class AsdfPydanticConverter(Converter):
         return obj.asdf_yaml_tree()
 
     def from_yaml_tree(self, node, tag, ctx):
-        return self._tag_to_class[tag].parse_obj(node)
+        return self._tag_to_class[tag].model_validate(node)

--- a/asdf_pydantic/model.py
+++ b/asdf_pydantic/model.py
@@ -15,7 +15,7 @@ class AsdfPydanticModel(BaseModel):
     ASDF Serialization and Deserialization:
         Serialize to ASDF yaml tree is done with the
         py:classmethod`AsdfPydanticModel.asdf_yaml_tree()` and deserialize to an
-        AsdfPydanticModel object with py:meth`AsdfPydanticModel.parse_obj()`.
+        AsdfPydanticModel object with py:meth`AsdfPydanticModel.model_validate()`.
     """
 
     _tag: ClassVar[str | TagDefinition]

--- a/asdf_pydantic/model.py
+++ b/asdf_pydantic/model.py
@@ -24,7 +24,7 @@ class AsdfPydanticModel(BaseModel):
     def asdf_yaml_tree(self) -> dict:
         d = {}
         for field_key, v in self.__dict__.items():
-            if field_key not in self.__fields__:
+            if field_key not in self.model_fields:
                 continue
 
             if isinstance(v, AsdfPydanticModel):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,8 +1,50 @@
 import pytest
 import yaml
 from asdf.extension import TagDefinition
+from pydantic import BaseModel
 
 from asdf_pydantic import AsdfPydanticModel
+
+
+########################################################################################
+# ASDF Tree
+########################################################################################
+def test_asdf_yaml_tree_sanity():
+    class TestModel(AsdfPydanticModel):
+        foo: str
+
+    model = TestModel(foo="bar")
+    assert model.asdf_yaml_tree() == {"foo": "bar"}
+
+
+def test_asdf_yaml_tree_nested_dict():
+    class NestedTestModel(AsdfPydanticModel):
+        nested: dict
+
+    model = NestedTestModel(nested={"foo": "bar"})
+    assert model.asdf_yaml_tree() == {"nested": {"foo": "bar"}}
+
+
+def test_asdf_yaml_tree_nested_basemodel():
+    class TestModel(BaseModel):
+        foo: str
+
+    class NestedTestModel(AsdfPydanticModel):
+        nested: TestModel
+
+    model = NestedTestModel(nested=TestModel(foo="bar"))
+    assert model.asdf_yaml_tree() == {"nested": {"foo": "bar"}}
+
+
+def test_asdf_yaml_tree_nested_asdf_pydantic_model():
+    class TestModel(AsdfPydanticModel):
+        foo: str
+
+    class NestedTestModel(AsdfPydanticModel):
+        nested: TestModel
+
+    model = NestedTestModel(nested=TestModel(foo="bar"))
+    assert model.asdf_yaml_tree() == {"nested": TestModel(foo="bar")}
 
 
 ########################################################################################


### PR DESCRIPTION
works on #42 