### PR TITLE
ci: add create ASDF version supported badge

### DIFF
--- a/.github/workflows/badges.yml
+++ b/.github/workflows/badges.yml
@@ -1,0 +1,22 @@
+name: Update badges
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-badges:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Create ASDF version supported badge
+      uses: schneegans/dynamic-badges-action@v1.7.0
+      with:
+        auth: ${{ secrets.GIST_TOKEN }}
+        gistID: 78d5f642122c6136118836b54899b7d4
+        filename: badges.json
+        label: asdf
+        message: 3 | 4
+        color: orange

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
+        args: [--verbose]
 
   - repo: local
     hooks:


### PR DESCRIPTION
- **ci: turn on verbose conventional-pre-commit**
- **ci: create ASDF version supported badge on push**
